### PR TITLE
Make block partitioner more robust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ script:
      make install &&
      cd ../.. &&
      cmake 
-     -DCMAKE_PREFIX_PATH="$HOME/MSTK-3.3.3-install;/usr/include/trilinos"
+     -DCMAKE_PREFIX_PATH="$HOME/MSTK-3.3.4-install;/usr/include/trilinos"
      -DCMAKE_INSTALL_PREFIX=$HOME/Jali
      -DCMAKE_BUILD_TYPE=Release
      -DENABLE_MSTK=yes

--- a/config/SuperBuild/TPLVersions.cmake
+++ b/config/SuperBuild/TPLVersions.cmake
@@ -85,6 +85,7 @@
 #   1.1.0       - MSTK updated to 3.0.3, UnitTest++ to 2.0.0, Trilinos to 12.10.1, HDF5 1.8.18, Seacas to #173a1e6, zlib to 1.2.11, Boost to 1.63.0, NetCDF to 4.5.0, MOAB to 5.0.0,
 #   1.2.0       - MSTK updated to 3.1.1
 #   1.3.0       - MSTK updated to 3.3.2
+#   1.4.0       - MSTK updated to 3.3.4
 
 include(CMakeParseArguments)
 
@@ -268,7 +269,7 @@ set(ExodusII_MD5_SUM       cfd240dbc1251b08fb1d0ee2de40a44c)
 #
 set(MSTK_VERSION_MAJOR 3)
 set(MSTK_VERSION_MINOR 3)
-set(MSTK_VERSION_PATCH 2)
+set(MSTK_VERSION_PATCH 4)
 if (MSTK_VERSION_PATCH)
   set(MSTK_VERSION ${MSTK_VERSION_MAJOR}.${MSTK_VERSION_MINOR}.${MSTK_VERSION_PATCH})
 else (MSTK_VERSION_PATCH)
@@ -277,7 +278,7 @@ endif (MSTK_VERSION_PATCH)
 set(MSTK_URL_STRING     "https://github.com/MeshToolkit/MSTK/archive")
 set(MSTK_ARCHIVE_FILE   ${MSTK_VERSION}.tar.gz)
 set(MSTK_SAVEAS_FILE    MSTK-${MSTK_VERSION}.tar.gz)
-set(MSTK_MD5_SUM        37c2616d10b953ce1f4eb239d35a1b93)
+set(MSTK_MD5_SUM        5ba0a5e18c14a34ac00a4047c9e7c9d9)
 
 #
 # TPL: MOAB

--- a/src/mesh/CMakeLists.txt
+++ b/src/mesh/CMakeLists.txt
@@ -67,6 +67,7 @@ set(JALI_MESH_headers
   Mesh.hh
   MeshTile.hh
   MeshSet.hh
+  block_partition.hh
   )
 list(TRANSFORM JALI_MESH_headers PREPEND "${JALI_MESH_SOURCE_DIR}/")
 
@@ -74,6 +75,7 @@ set(JALI_MESH_sources
   Mesh.cc
   MeshTile.cc
   MeshSet.cc
+  block_partition.cc
   )
 
 
@@ -291,7 +293,12 @@ if (BUILD_TESTS)
     NPROCS 4
     SOURCE test/Main.cc test/test_meshsets.cc
     LINK_LIBS jali_mesh jali_mesh_factory ${UnitTest++_LIBRARIES})
-    
+
+  # test block partitioning
+  add_Jali_test(block_partitioning block_partitioning
+    KIND unit
+    SOURCE test/Main.cc test/test_block_partition.cc
+    LINK_LIBS jali_mesh ${UnitTest++_LIBRARIES})
 
 endif()
   

--- a/src/mesh/Mesh.hh
+++ b/src/mesh/Mesh.hh
@@ -69,6 +69,8 @@
 #include "MeshTile.hh"
 #include "MeshSet.hh"
 
+#include "block_partition.hh"
+
 #define JALI_CACHE_VARS 1  // Switch to 0 to turn caching off
 
 //! \mainpage Jali
@@ -1335,27 +1337,6 @@ class Mesh {
   //                                   int const tileid) {}
   //  void set_master_tile_ID_of_corner(Entity_ID const cornerid,
   //                                    int const tileid) {}
-
-  //! @brief Get the partitioning of a regular mesh such that each
-  //! partition is a rectangular block
-  //!
-  //! @param dim Dimension of problem - 1, 2 or 3
-  //! @param domain 2*dim values for min/max of domain
-  //!  (xmin, xmax, ymin, ymax, zmin, zmax)
-  //! @param num_cells_in_dir  number of cells in each direction
-  //! @param num_blocks_requested number of blocks requested
-  //! @param blocklimits min/max limits for each block
-  //! @param blocknumcells num cells in each direction for blocks
-  //!
-  //! Returns 1 if successful, 0 otherwise
-  
-  int
-  block_partition_regular_mesh(int const dim,
-                               double const * const domain,
-                               int const * const num_cells_in_dir,
-                               int const num_blocks_requested,
-                               std::vector<std::array<double, 6>> *blocklimits,
-                               std::vector<std::array<int, 3>> *blocknumcells);
 
 
   // Data

--- a/src/mesh/block_partition.cc
+++ b/src/mesh/block_partition.cc
@@ -1,0 +1,275 @@
+/*
+ Copyright (c) 2019, Triad National Security, LLC
+ All rights reserved.
+
+ Copyright 2019. Triad National Security, LLC. This software was
+ produced under U.S. Government contract 89233218CNA000001 for Los
+ Alamos National Laboratory (LANL), which is operated by Triad
+ National Security, LLC for the U.S. Department of Energy. 
+ All rights in the program are reserved by Triad National Security,
+ LLC, and the U.S. Department of Energy/National Nuclear Security
+ Administration. The Government is granted for itself and others acting
+ on its behalf a nonexclusive, paid-up, irrevocable worldwide license
+ in this material to reproduce, prepare derivative works, distribute
+ copies to the public, perform publicly and display publicly, and to
+ permit others to do so
+
+ 
+ This is open source software distributed under the 3-clause BSD license.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are
+ met:
+ 
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. Neither the name of Triad National Security, LLC, Los Alamos
+    National Laboratory, LANL, the U.S. Government, nor the names of its
+    contributors may be used to endorse or promote products derived from this
+    software without specific prior written permission.
+
+ 
+ THIS SOFTWARE IS PROVIDED BY TRIAD NATIONAL SECURITY, LLC AND
+ CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ TRIAD NATIONAL SECURITY, LLC OR CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include <vector>
+#include <array>
+#include <algorithm>
+#include <cassert>
+
+
+namespace Jali {
+
+
+/*
+  Get the partitioning of a regular mesh such that each
+  partition is a rectangular block
+
+  dim                   Dimension of problem - 1, 2 or 3
+  domain                2*dim values for min/max of domain
+                        (xmin, xmax, ymin, ymax, zmin, zmax)
+  num_cells_in_dir      number of cells in each direction
+  num_blocks_requested  number of blocks requested
+  block_start_indices   start node/cell indices for each block
+  block_num_cells num   cells in each direction for blocks
+
+  Returns 1 if successful, 0 otherwise
+*/
+
+int block_partition_regular_mesh(int const dim,
+                                 double const * const domain,
+                                 int const * const num_cells_in_dir,
+                                 int const num_blocks_requested,
+                                 std::vector<std::array<int, 3>> *block_start_indices,
+                                 std::vector<std::array<int, 3>> *block_num_cells) {
+
+  // Create local block arrays that are larger than the requested number of
+  // blocks. The extra storage is for temporary blocks while we are subdividing
+
+  int nblocks = 1;
+  int nblocks_in_dir[3] = {1, 1, 1};
+  int nblockcells_in_dir[3] = {0, 0, 0};
+  for (int i = 0; i < dim; i++)
+    nblockcells_in_dir[i] = num_cells_in_dir[i];
+
+  int ncells_total = 1;
+  for (int i = 0; i < dim; i++)
+    ncells_total *= num_cells_in_dir[i];
+  assert (num_blocks_requested <= ncells_total);
+    
+  
+  if (num_blocks_requested > 1) {
+    // First try bisection
+    
+    bool done = false;
+    while (!done) {
+      bool bisected = false;
+      if (nblockcells_in_dir[0]%2 == 0) {  // even number of cells in x
+        if (2*nblocks <= num_blocks_requested) {
+          nblockcells_in_dir[0] /= 2;
+          nblocks *= 2;
+          nblocks_in_dir[0] *= 2;
+          bisected = true;
+          
+          if (nblocks == num_blocks_requested) {
+            done = 1;
+            continue;
+          }
+        }
+      }
+      if (dim > 1 && nblockcells_in_dir[1]%2 == 0) {  // even num of cells in y
+        if (2*nblocks <= num_blocks_requested) { 
+          nblockcells_in_dir[1] /= 2;
+          nblocks *= 2;
+          nblocks_in_dir[1] *= 2;
+          
+          bisected = true;
+          if (nblocks == num_blocks_requested) {
+            done = 1;
+            continue;
+          }
+        }
+      }
+      if (dim > 2 && nblockcells_in_dir[2]%2 == 0) {  // even num of cells in z
+        if (2*nblocks <= num_blocks_requested) {
+          nblockcells_in_dir[2] /= 2;
+          nblocks *= 2;
+          nblocks_in_dir[2] *= 2;
+          bisected = true;
+          
+          if (nblocks == num_blocks_requested) {
+            done = 1;
+            continue;
+          }
+        }
+      }
+      if (!bisected) {
+        // Reached a state where we cannot evenly subdivide the number
+        // of elements in any one direction
+        done = 1;
+      }
+    }
+  }
+
+  std::array<int, 3> iarray0 = {0, 0, 0};
+  std::vector<std::array<int, 3>>
+      bnumcells(8*nblocks_in_dir[0]*nblocks_in_dir[1]*nblocks_in_dir[2],
+                iarray0);
+  std::vector<std::array<int, 3>>
+      blimits(8*nblocks_in_dir[0]*nblocks_in_dir[1]*nblocks_in_dir[2],
+              iarray0);
+
+  // Populate the block details
+  int partnum = 0;
+  for (int i = 0; i < nblocks_in_dir[0]; i++) {
+    for (int j = 0; j < nblocks_in_dir[1]; j++) {
+      for (int k = 0; k < nblocks_in_dir[2]; k++) {
+        blimits[partnum][0] = i*nblockcells_in_dir[0];
+        bnumcells[partnum][0] = nblockcells_in_dir[0];
+
+        if (dim > 1) {
+          blimits[partnum][1] = j*nblockcells_in_dir[1];
+          bnumcells[partnum][1] = nblockcells_in_dir[1];
+
+          if (dim > 2) {
+            blimits[partnum][2] = k*nblockcells_in_dir[2];
+            bnumcells[partnum][2] = nblockcells_in_dir[2];
+          }
+        }
+        partnum++;
+      }
+    }
+  }
+
+  if (nblocks != num_blocks_requested) {  // assuming that nblocks <= num_blocks_requested
+
+    // Start dividing the blocks as unevenly to get the number of
+    // partitions we need
+    
+    bool done = false;
+    while (!done) {
+      for (int dir = 0; dir < dim; dir++) {  // split blocks in x, then y etc
+        int nnewblocks = 0;
+        for (int ib = 0; ib < nblocks; ib++) {
+          if (bnumcells[ib][0] == 0 && bnumcells[ib][1] == 0 &&
+              bnumcells[ib][2] == 0) continue;  // Blanked out block
+          
+          int ncells1 = bnumcells[ib][dir]/2;
+          int ncells2 = bnumcells[ib][dir] - ncells1;
+          if (ncells1 == 0 || ncells2 == 0) continue;
+          
+          // Make two new partitions at the end of the list
+          // But first make sure there is enough room to hold them
+
+          int nalloc = bnumcells.size();
+          if (nalloc < nblocks + nnewblocks + 2) {
+            nalloc *= 2;
+            bnumcells.resize(nalloc, iarray0);
+            blimits.resize(nalloc, iarray0);
+          }
+          
+          // Copy the original block details over to the first child block
+          int ib1 = nblocks + nnewblocks;
+          for (int dir1 = 0; dir1 < dim; dir1++) {
+            bnumcells[ib1][dir1] = bnumcells[ib][dir1];
+            blimits[ib1][dir1] = blimits[ib][dir1];
+          }
+          /* overwrite the data in the direction of the refinement */
+          bnumcells[ib1][dir] = ncells1;
+          blimits[ib1][dir] = blimits[ib][dir];
+          
+          // copy the initial block details over to the second child block
+          int ib2 = nblocks + nnewblocks + 1;
+          for (int dir1 = 0; dir1 < dim; dir1++) {
+            bnumcells[ib2][dir1] = bnumcells[ib][dir1];
+            blimits[ib2][dir1] = blimits[ib][dir1];
+          }
+          /* overwrite the data in the direction of the refinement */
+          bnumcells[ib2][dir] = ncells2;
+          blimits[ib2][dir] = blimits[ib][dir] + ncells1;
+          
+          // Blank out the parent block
+          bnumcells[ib][0] = bnumcells[ib][1] = bnumcells[ib][2] = 0;
+          nnewblocks += 2;
+          
+          // Check if we reached the requested number of blocks. Each
+          // block that was split into two will cause the loss of one
+          // block and gain of two new blocks, so the net gain is just
+          // nnewblocks/2
+          
+          if (nblocks + nnewblocks/2 >= num_blocks_requested) {
+            done = 1;
+            break;
+          }
+        }
+        
+        // Squeeze out the blocks that were split and dummied out
+        for (int ib = nblocks-1; ib >= 0; ib--) {
+          if (bnumcells[ib][0] == 0 && bnumcells[ib][1] == 0 &&
+              bnumcells[ib][2] == 0) {  // dummy block
+            for (int ib1 = ib; ib1 < nblocks+nnewblocks-1; ib1++) {
+              for (int dir1 = 0; dir1 < 3; dir1++) {
+                bnumcells[ib1][dir1] = bnumcells[ib1+1][dir1];
+                blimits[ib1][dir1] = blimits[ib1+1][dir1];
+              }
+            }
+            // Blank out the last block
+            bnumcells[nblocks+nnewblocks-1][0] =
+                bnumcells[nblocks+nnewblocks-1][1] =
+                bnumcells[nblocks+nnewblocks-1][2] = 0;
+            nblocks--;
+          }
+        }
+        nblocks += nnewblocks;
+        if (done)
+          break;
+      }
+    }
+  }  // if (nblocks != num_blocks_requested)
+
+  blimits.resize(nblocks);
+  bnumcells.resize(nblocks);
+
+  block_start_indices->resize(nblocks);
+  block_num_cells->resize(nblocks);
+  std::copy(blimits.begin(), blimits.end(), block_start_indices->begin());
+  std::copy(bnumcells.begin(), bnumcells.end(), block_num_cells->begin());
+
+  return 1;
+}
+
+}  // close namespace Jali

--- a/src/mesh/block_partition.hh
+++ b/src/mesh/block_partition.hh
@@ -1,0 +1,77 @@
+/*
+ Copyright (c) 2019, Triad National Security, LLC
+ All rights reserved.
+
+ Copyright 2019. Triad National Security, LLC. This software was
+ produced under U.S. Government contract 89233218CNA000001 for Los
+ Alamos National Laboratory (LANL), which is operated by Triad
+ National Security, LLC for the U.S. Department of Energy. 
+ All rights in the program are reserved by Triad National Security,
+ LLC, and the U.S. Department of Energy/National Nuclear Security
+ Administration. The Government is granted for itself and others acting
+ on its behalf a nonexclusive, paid-up, irrevocable worldwide license
+ in this material to reproduce, prepare derivative works, distribute
+ copies to the public, perform publicly and display publicly, and to
+ permit others to do so
+
+ 
+ This is open source software distributed under the 3-clause BSD license.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are
+ met:
+ 
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. Neither the name of Triad National Security, LLC, Los Alamos
+    National Laboratory, LANL, the U.S. Government, nor the names of its
+    contributors may be used to endorse or promote products derived from this
+    software without specific prior written permission.
+
+ 
+ THIS SOFTWARE IS PROVIDED BY TRIAD NATIONAL SECURITY, LLC AND
+ CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ TRIAD NATIONAL SECURITY, LLC OR CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include <vector>
+#include <array>
+
+
+/*!
+  @brief Get the partitioning of a regular mesh such that each
+  partition is a rectangular block
+
+  @param dim                   Dimension of problem - 1, 2 or 3
+  @param domain                2*dim values for min/max of domain
+                               (xmin, xmax, ymin, ymax, zmin, zmax)
+  @param num_cells_in_dir      number of cells in each direction
+  @param num_blocks_requested  number of blocks requested
+  @param block_start_indices   start node/cell indices for each block
+  @param block_num_cells       num cells in each direction for blocks
+
+  Returns 1 if successful, 0 otherwise
+*/
+
+namespace Jali {
+
+int block_partition_regular_mesh(int const dim,
+                                 double const * const domain,
+                                 int const * const num_cells_in_dir,
+                                 int const num_blocks_requested,
+                                 std::vector<std::array<int, 3>> *block_start_indices,
+                                 std::vector<std::array<int, 3>> *block_num_cells);
+
+}

--- a/src/mesh/mesh_mstk/CMakeLists.txt
+++ b/src/mesh/mesh_mstk/CMakeLists.txt
@@ -136,7 +136,6 @@ if (BUILD_TESTS)
     test/test_hex_gen_3x3x3.cc
     test/test_quad_gen_3x3.cc
     test/test_write_read_fields.cc
-    test/test_block_partition.cc
     LINK_LIBS jali_mstk_mesh ${UnitTest++_LIBRARIES}) 
   
   # Test: mstk_mesh_parallel
@@ -151,7 +150,7 @@ if (BUILD_TESTS)
     test/test_hex_gen_5x5x5_par.cc
     test/test_edges_4P.cc
     LINK_LIBS jali_mstk_mesh ${UnitTest++_LIBRARIES})
-  
+    
   # Test: mstk_mesh_parallel
   add_Jali_test(mstk_mesh_parallel8 test_parallel8_mstk_mesh
     KIND unit

--- a/src/mesh/mesh_mstk/Mesh_MSTK.hh
+++ b/src/mesh/mesh_mstk/Mesh_MSTK.hh
@@ -596,20 +596,61 @@ class Mesh_MSTK : public Mesh {
   other_internal_name_of_set(const JaliGeometry::RegionPtr r,
                              const Entity_kind entity_kind) const;
 
+  /*!
+    Generate a structured 3D mesh with regularly spaced points along
+    coordinate directions
+    
+    @param mesh  Mesh object to be populated
+    @param X0    Min X coordinate of global domain
+    @param Y0    Min Y coordinate of global domain
+    @param Z0,   Min Z coordinate of global domain
+    @param X1    Max X coordinate of global domain
+    @param Y1    Max Y coordinate of global domain
+    @param Z1    Max Z coordinate of global domain
+    @param NX    Global number of cells in X direction
+    @param NY    Global number of cells in Y direction
+    @param NZ    Global number of cells in Z direction
+    
+    Optional for serial mesh
+    @param i0    Start node/cell index of partition (defaults to 0 for serial mesh)
+    @param j0    Start node/cell index of partition (defaults to 0 for serial mesh)
+    @param k0    Start node/cell index of partition (defaults to 0 for serial mesh)
+    @param nx    Number of cells in X direction of partition (defaults to NX for serial mesh)
+    @param ny    Number of cells in X direction of partition (defaults to NY for serial mesh)
+    @param nz    Number of cells in X direction of partition (defaults to NZ for serial mesh)
+  */
+   
+    
   int  generate_regular_mesh(Mesh_ptr mesh,
-			     double x0, double y0, double z0,
-                             double x1, double y1, double z1,
-			     int nx, int ny, int nz,
-			     double X0 = 0.0, double Y0 = 0.0, double Z0 = 0.0,
-			     double X1 = 0.0, double Y1 = 0.0, double Z1 = 0.0,
-			     int NX = 0, int NY = 0, int NZ = 0);
+			     double X0, double Y0, double Z0,
+			     double X1, double Y1, double Z1,
+			     int NX, int NY, int NZ,
+                             int i0=0, int j0=0, int k0=0,
+                             int nx=0, int ny=0, int nz=0);
 
+  /*!
+    Generate a structured 2D mesh with regularly spaced points along
+    coordinate directions
+    
+    @param mesh  Mesh object to be populated
+    @param X0    Min X coordinate of global domain
+    @param Y0    Min Y coordinate of global domain
+    @param X1    Max X coordinate of global domain
+    @param Y1    Max Y coordinate of global domain
+    @param NX    Global number of cells in X direction
+    @param NY    Global number of cells in Y direction
+    
+    Optional for serial mesh
+    @param i0    Start node/cell index of partition (defaults to 0 for serial mesh)
+    @param j0    Start node/cell index of partition (defaults to 0 for serial mesh)
+    @param nx    Number of cells in X direction of partition (defaults to NX for serial mesh)
+    @param ny    Number of cells in X direction of partition (defaults to NY for serial mesh)
+  */
+   
   int  generate_regular_mesh(Mesh_ptr mesh,
-			     double x0, double y0, double x1, double y1,
-			     int nx, int ny,
-			     double X0 = 0.0, double Y0 = 0.0,
-			     double X1 = 0.0, double Y1 = 0.0,
-			     int NX = 0, int NY = 0);
+			     double X0, double Y0, double X1, double Y1,
+			     int NX, int NY,
+                             int i0=0, int j0=0, int nx=0, int ny=0);
 
   void extract_mstk_mesh(const Mesh_MSTK& inmesh,
                          const List_ptr entity_ids,


### PR DESCRIPTION
Make block partitioning and generation of parallel regular meshes more robust by minimizing conversions of block limits from integers to doubles and back 